### PR TITLE
Update filter_assembly.xml

### DIFF
--- a/galaxy_wrappers/01_Filter_Assemblies/filter_assembly.xml
+++ b/galaxy_wrappers/01_Filter_Assemblies/filter_assembly.xml
@@ -1,7 +1,7 @@
 <tool name="Filter assemblies" id="filter_assemblies" version="2.0.4">
 
     <description>
-        Filter the outputs of Velvet or Trinity assemblies
+        Filter the outputs of Spades, Velvet or Trinity assemblies
     </description>
 
     <macros>
@@ -34,7 +34,7 @@
 
     <inputs>
         <param name="inputs" type="data" format="fasta" multiple="true" label="Input files" />
-        <param name="percent_identity" type="integer" value="100" label="Overlap percent identity cutoff" help="Cap3 parameter (-p N); minimum percent identity of an overlap. The specified value should be more than 65%." />
+        <param name="percent_identity" type="integer" value="90" label="Overlap percent identity cutoff" help="Cap3 parameter (-p N); minimum percent identity of an overlap. The specified value should be more than 65%." />
         <param name="overlap_length" type="integer" value="60" label="Overlap length cutoff" help="Cap3 parameter (-o N); minimum length of an overlap (in base pairs). The specified value should be more than 15 base pairs." />
         <param name="length_seq_max" type="integer" value="100" label="Minimum sequence length" help="Keep sequences which length is higher than the minimum sequence length  " />
     </inputs>

--- a/galaxy_wrappers/01_Filter_Assemblies/filter_assembly.xml
+++ b/galaxy_wrappers/01_Filter_Assemblies/filter_assembly.xml
@@ -1,4 +1,4 @@
-<tool name="Filter assemblies" id="filter_assemblies" version="2.0.4">
+<tool name="Filter assemblies" id="filter_assemblies" version="2.0.5">
 
     <description>
         Filter the outputs of Spades, Velvet or Trinity assemblies

--- a/scripts/01_Filter_Assemblies/S01_script_to_choose.py
+++ b/scripts/01_Filter_Assemblies/S01_script_to_choose.py
@@ -5,7 +5,6 @@ import sys
 
 from Bio import SeqIO
 
-
 def fasta_formatter(input_file, output_file):
     """
     Reformats the input FASTA file to ensure that sequences
@@ -26,7 +25,6 @@ def fasta_formatter(input_file, output_file):
                 sequence += line.strip()
         if sequence:
             outfile.write(sequence + '\n')
-
 
 def reformat_headers(input_file, output_file, prefix):
     """
@@ -77,7 +75,6 @@ def rename_fasta_headers(input_fasta, output_fasta):
 
     # Write output file with new headers
     SeqIO.write(modified_sequences, output_fasta, "fasta")
-
 
 def main():
     if len(sys.argv) < 5:
@@ -158,9 +155,6 @@ def main():
         os.remove(cap_singlets_file)
         os.remove(cap_contigs_file)
         os.remove(name_fasta_final)
-
-
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The default Overlap percent identity cutoff value needs to be changed to 90 instead of 100 due to its incorrect CAP3 outputs.